### PR TITLE
Fix missing Chart.js annotation plugin

### DIFF
--- a/neural-simulator.html
+++ b/neural-simulator.html
@@ -6,6 +6,8 @@
     <title>神經傳導模擬器</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+    <!-- 用於在圖表上繪製閾值等標記 -->
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@1.1.0/dist/chartjs-plugin-annotation.min.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- load `chartjs-plugin-annotation` in neural-simulator

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842f35b4400832c873f05d4eef973ba